### PR TITLE
Fixed crashing error where RNFirebase was not linked

### DIFF
--- a/Dev/react-native.config.js
+++ b/Dev/react-native.config.js
@@ -8,30 +8,4 @@ module.exports = {
         "./assets/images/",
         "./config/fonts.js"
     ],
-    dependencies: {
-        'react-native-gesture-handler': {
-            platforms: {
-                ios: null,
-                android: null
-            },
-        },
-        'react-native-firebase': {
-            platforms: {
-                ios: null,
-                android: null
-            },
-        },
-        'react-native-reanimated': {
-            platforms: {
-                ios: null,
-                android: null
-            },
-        },
-        'react-native-vector-icons': {
-            platforms: {
-                ios: null,
-                android: null
-            },
-        },
-    },
 };


### PR DESCRIPTION
- Fixed a crashing issue where an incorrect dependency was put in react-native-config.js so RNFirebase ended up not linking correctly.