### PR TITLE
Fixed StudentCard backgroud issue

### DIFF
--- a/Dev/src/components/StudentCard.js
+++ b/Dev/src/components/StudentCard.js
@@ -19,7 +19,7 @@ export default class StudentCard extends FontLoadingComponent {
             //The style of the card as a whole. Inside the card, you have the image,
             //student name, and student assignment
             <TouchableOpacity
-                style={[styles.cardStyle, { background }]}
+                style={[styles.cardStyle, { backgroundColor: background }]}
                 borderColor={colors.black}
                 //The on press function is for when the teacher clicks the card, the color of it 
                 //should change depending on the behavior (i.e attendance screen)


### PR DESCRIPTION
Fixed Issue #98: StudentCard component would never had a background color. This was due to a badly named style.